### PR TITLE
Fix build error due to modified API visibility

### DIFF
--- a/cglue-gen/Cargo.toml
+++ b/cglue-gen/Cargo.toml
@@ -12,7 +12,7 @@ categories = [ "api-bindings", "accessibility", "parsing" ]
 readme = "../README.md"
 
 [dependencies]
-syn = { version = "1", features = ["full", "extra-traits"] }
+syn = { version = "=1.0.97", features = ["full", "extra-traits"] }
 proc-macro2 = "1"
 quote = "1"
 proc-macro-crate = "=1.1.0"

--- a/cglue-gen/Cargo.toml
+++ b/cglue-gen/Cargo.toml
@@ -12,7 +12,7 @@ categories = [ "api-bindings", "accessibility", "parsing" ]
 readme = "../README.md"
 
 [dependencies]
-syn = { version = "=1.0.97", features = ["full", "extra-traits"] }
+syn = { version = "1", features = ["full", "extra-traits", "parsing"] }
 proc-macro2 = "1"
 quote = "1"
 proc-macro-crate = "=1.1.0"

--- a/cglue-gen/src/func.rs
+++ b/cglue-gen/src/func.rs
@@ -2,7 +2,7 @@ use super::generics::{GenericType, ParsedGenerics};
 use proc_macro2::TokenStream;
 use quote::*;
 use std::collections::BTreeMap;
-use syn::{group::parse_braces, parse::*, punctuated::Punctuated, token::Comma, Type, *};
+use syn::{__private::parse_braces, parse::*, punctuated::Punctuated, token::Comma, Type, *};
 
 const FN_PREFIX: &str = "cglue_wrapped_";
 

--- a/cglue-gen/src/trait_groups.rs
+++ b/cglue-gen/src/trait_groups.rs
@@ -5,6 +5,7 @@ use itertools::*;
 use proc_macro2::TokenStream;
 use quote::*;
 use std::collections::HashMap;
+use syn::__private::parse_braces;
 use syn::parse::{Parse, ParseStream};
 use syn::*;
 
@@ -81,7 +82,7 @@ impl Parse for TraitGroup {
         let generics = input.parse()?;
 
         // TODO: parse associated type defs here
-        group::parse_braces(input).ok();
+        parse_braces(input).ok();
 
         input.parse::<Token![,]>()?;
         let mandatory_traits = parse_maybe_braced::<Path>(input)?;
@@ -248,7 +249,7 @@ impl Parse for TraitGroupImpl {
             Ok(ParsedGenerics {
                 gen_where_bounds, ..
             }) => {
-                group::parse_braces(input).ok();
+                parse_braces(input).ok();
                 ParsedGenerics {
                     gen_where_bounds,
                     ..generics

--- a/cglue-gen/src/util.rs
+++ b/cglue-gen/src/util.rs
@@ -1,6 +1,7 @@
 use proc_macro2::TokenStream;
 use proc_macro_crate::{crate_name, FoundCrate};
 use quote::{format_ident, quote};
+use syn::__private::parse_braces;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::token::Colon2;
@@ -50,7 +51,7 @@ pub fn crate_path_fixed() -> Option<FoundCrate> {
 pub fn parse_maybe_braced<T: Parse>(input: ParseStream) -> Result<Vec<T>> {
     let mut ret = vec![];
 
-    if let Ok(braces) = syn::group::parse_braces(input) {
+    if let Ok(braces) = parse_braces(input) {
         let content = braces.content;
 
         while !content.is_empty() {


### PR DESCRIPTION
Closes https://github.com/h33p/cglue/issues/6 by accessing the `parse_braces` function through the `__private` module as described [here](https://github.com/dtolnay/syn/commit/0000e6e911e456c82d90e4bf5937b4a4edaf643f).